### PR TITLE
added saving improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,9 +318,11 @@
 			<div class="buttons">
 				<button id="clearcoords" type="button" style="background-color: rgb(208, 137, 114);">Clear All Drawings</button>
 			</div>
+			<hr>
 			<div class="buttons">
-				<button id="save_map" type="button">Save Map</button>
-				<button id="load_map" type="button">Load Map</button>
+				<input type="file" id="map_file" style="display: none;" />
+				<button id="import_map" type="button">Import Map</button>
+				<button id="export_map" type="button">Export Map</button>
 			</div>
 		</div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -646,6 +646,8 @@ require([
 		}
 
 		redrawMap();
+		// update map object in local storage
+		localStorage.setItem("mapObjects", JSON.stringify(mapObjects));
 	});
 
 	view.on("drag", (event) => {
@@ -937,17 +939,36 @@ require([
 		redrawMap();
 	}
 
-	document.getElementById('save_map').onclick = function () {
-		localStorage.setItem("mapObjects", JSON.stringify(mapObjects));
+	document.getElementById('export_map').onclick = function () {
+		var mapObject = JSON.stringify(mapObjects),
+			a = document.createElement("a"),
+		    blob = new Blob([mapObject], {type: "octet/stream"}),
+		    url = window.URL.createObjectURL(blob);
+		a.href = url;
+		a.download = 'mapObject.json';
+		a.click();
+		window.URL.revokeObjectURL(url);
 	}
 
+	document.getElementById('import_map').onclick = function() {
+		// causes file input to prompt for file
+		document.getElementById('map_file').click();
+		// if user did upload file, goes to 'map_file'.onchange (below)
+	}
 
-	document.getElementById('load_map').onclick = function () {
-		if(!localStorage.hasOwnProperty("mapObjects"))
-			return;
-
-		mapObjects = JSON.parse(localStorage.getItem("mapObjects"));	
-		redrawMap();
+	document.getElementById('map_file').onchange = function() {
+		var files = document.getElementById('map_file').files;
+		if (files.length <= 0) {
+		    return false;
+		} 
+		var fr = new FileReader();
+		fr.onload = function(e) { 
+			mapObjects = JSON.parse(e.target.result);
+			localStorage.setItem("mapObjects", JSON.stringify(mapObjects));
+			redrawMap();
+		}
+		  
+		fr.readAsText(files.item(0));
 	}
 
 	//Details menu
@@ -1214,6 +1235,11 @@ require([
 		document.getElementById("form_position_details").style.display = "none";
 		menuPoint = undefined;
 	} 
+
+	if(localStorage.hasOwnProperty("mapObjects")) {
+		mapObjects = JSON.parse(localStorage.getItem("mapObjects"));	
+		redrawMap();
+	}
 
 });
 


### PR DESCRIPTION
#10

- every drawing change (`view.on("immediate-click"`) updates the object in local storage
- checks for existing object in local storage on map load
- changed load button to import button which prompts for .json file and loads it
- changed save button to export button which automatically downloads the map as json

loading the map object into local storage on every change *might* cause performance issues if there are many drawings, but I doubt it would very be noticeable unless there was an unreasonable amount of them