### PR TITLE
Docs: Add local dev instructions

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,6 +1,6 @@
 # Contributing Guide
 
-As mentioned in the ReadMe, the framework used is ArcGIS, here's some info on it:
+As mentioned in the README, the framework used is ArcGIS, here's some info on it:
 - https://developers.arcgis.com/javascript/latest/ 
 - https://community.esri.com/t5/arcgis-online-documents/tkb-p/arcgis-online-docs
 
@@ -21,6 +21,19 @@ Here's a general rundown:
 - [grid_winds.js](js/grid_winds.js) Defines trade winds
 
 - [polygon_definitions.js](js/polygon_definitions.js) Abandon hope all ye who enter here
+
+
+## Running Locally
+
+The project is a static site with no build step, but it **must be served over HTTP**. Opening `index.html` directly as a `file://` URL silently fails to load island data, because the browser blocks the `fetch()` calls in [island_loader.js](js/island_loader.js).
+
+Any static file server works, so use whatever you already have. If you don't have one set up, MDN has an accessible guide: [Set up a local testing server](https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server). Serve from the repo root, then open the URL it prints.
+
+A few project-specific things that aren't super obvious:
+
+- You need an internet connection while running it. ArcGIS, jQuery, and Google Fonts load from their CDNs at runtime.
+- Island JSON and ArcGIS assets are cached aggressively; hard-refresh after edits (or use a server with live reload).
+- Failed or malformed island fetches currently only surface as `console.error` messages, so keep the devtools console open.
 
 
 ## Updating layer data

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Sailwind Web Map
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Originally by Sycosis and made with [ArcGIS](https://developers.arcgis.com/javascript/latest/), but it was eventually abandoned so I've forked it for further development. 
+
+Feel free to submit any PRs if you want :)
+
+See [Contributing.md](Contributing.md) for more info.
+
+## Running Locally
+
+Locally, the project is a static site with no build step, but it **must be served over HTTP**.
+Opening `index.html` directly as a `file://` URL will silently fail to load island data because the browser blocks the `fetch()` calls used in `js/island_loader.js`.
+
+You also need an internet connection while running it. ArcGIS, jQuery, and Google Fonts are loaded at runtime from their respective CDNs.
+
+Serve the project from its root directory using whichever of these you have installed:
+
+```bash
+# Python 3 (no install needed)
+python3 -m http.server 8000
+
+# Node, static server
+npx serve -l 8000
+
+# Node, static server with auto-reload on file changes
+npx live-server --port=8000
+```
+
+Then open <http://localhost:8000> in your browser.
+
+---
+
+### Tips & Notes
+
+- Always serve from the repo root.
+- The Island JSON and ArcGIS assets are cached aggressively. Hard-refresh after edits or use live-server.
+- Failed island fetches and malformed island data currently only surface as `console.error` messages.

--- a/README.md
+++ b/README.md
@@ -7,33 +7,3 @@ Originally by Sycosis and made with [ArcGIS](https://developers.arcgis.com/javas
 Feel free to submit any PRs if you want :)
 
 See [Contributing.md](Contributing.md) for more info.
-
-## Running Locally
-
-Locally, the project is a static site with no build step, but it **must be served over HTTP**.
-Opening `index.html` directly as a `file://` URL will silently fail to load island data because the browser blocks the `fetch()` calls used in `js/island_loader.js`.
-
-You also need an internet connection while running it. ArcGIS, jQuery, and Google Fonts are loaded at runtime from their respective CDNs.
-
-Serve the project from its root directory using whichever of these you have installed:
-
-```bash
-# Python 3 (no install needed)
-python3 -m http.server 8000
-
-# Node, static server
-npx serve -l 8000
-
-# Node, static server with auto-reload on file changes
-npx live-server --port=8000
-```
-
-Then open <http://localhost:8000> in your browser.
-
----
-
-### Tips & Notes
-
-- Always serve from the repo root.
-- The Island JSON and ArcGIS assets are cached aggressively. Hard-refresh after edits or use live-server.
-- Failed island fetches and malformed island data currently only surface as `console.error` messages.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,9 +1,0 @@
-# Sailwind Web Map
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-Originally by Sycosis and made with [ArcGIS](https://developers.arcgis.com/javascript/latest/), but it was eventually abandoned so I've forked it for further development. 
-
-Feel free to submit any PRs if you want :)
-
-See [Contributing.md](Contributing.md) for more info.


### PR DESCRIPTION
## Summary

- Added a _Running Locally_ section to the README outlining how to serve the app for development.
- Renames `ReadMe.md` to `README.md` to follow the filename convention.

## Why

There's no build step, but you have to serve it over HTTP. Opening `index.html` as a `file://` URL silently fails to load island data since the browser blocks the `fetch()` calls in `js/island_loader.js`.
This isn't documented anywhere, so new contributors lose time figuring it out. The new section covers the HTTP requirement, the runtime CDN/internet dependency, a few serve commands (Python and Node options), and tribal knowledge on the app's caching/debugging behavior.

## Changes
- New ` Running Locally` section: `file://` caveat, internet requirement, and serve
  commands (`python3 -m http.server`, `npx serve`, `npx live-server`).
- Added a **Tips & Notes** subsection
- Renamed `ReadMe.md` → `README.md`.

## Review notes
- No code or app behavior is affected.
- The rename is a case-only change and shows up in the diff as a delete + add rather than a pure rename since the file systems are case-insensitive.